### PR TITLE
feat: add support for tailwindcss language

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,9 @@ export function activate(context: vscode.ExtensionContext) {
     if (!editor) {
       return;
     }
-    if (editor.document.languageId !== "css") {
+
+    const languageId = editor.document.languageId;
+    if (languageId !== "css" && languageId !== "tailwindcss") {
       return;
     }
     const text = editor.document.getText();


### PR DESCRIPTION
Hi I really liked your extension and the work you did, but I currently use `tailwindcss` in my `.css` files, this to avoid warnings and have some extra snippets.

So I was testing locally adding an extra condition to `editor.document.languageId`, this way it also identifies `tailwindcss` as a language and shows the previews correctly.

Without the latter it only worked for the `css` language, maybe it would be a good idea to consider the same logic for `.postcss`, `scss`, among others.

I leave a video of test with the change incorporated in local, thanks again for your work!

https://github.com/dexxiez/shadcn-hsl-preview/assets/102609365/d3d1e53e-731d-4bc3-9807-c94d76ec91ff